### PR TITLE
Add env var check on CLOUDFLARE_PROXY on initialization

### DIFF
--- a/lib/cloudflare/rails/railtie.rb
+++ b/lib/cloudflare/rails/railtie.rb
@@ -101,16 +101,18 @@ module Cloudflare
       end
 
       initializer "cloudflare_rails.configure_rails_initialization" do
-        Rack::Request::Helpers.prepend CheckTrustedProxies
+        if ENV.fetch('CLOUDFLARE_PROXY', 'FALSE').upcase == 'TRUE'
+          Rack::Request::Helpers.prepend CheckTrustedProxies
 
-        ObjectSpace.each_object(Class).
-          select do |c|
+          ObjectSpace.each_object(Class).
+            select do |c|
             c.included_modules.include?(Rack::Request::Helpers) &&
-            !c.included_modules.include?(CheckTrustedProxies)
+              !c.included_modules.include?(CheckTrustedProxies)
           end.
-          map { |c| c .prepend CheckTrustedProxies }
+            map { |c| c .prepend CheckTrustedProxies }
 
-        ActionDispatch::RemoteIp.prepend RemoteIpProxies
+          ActionDispatch::RemoteIp.prepend RemoteIpProxies
+        end
       end
     end
   end

--- a/spec/cloudflare/rails_spec.rb
+++ b/spec/cloudflare/rails_spec.rb
@@ -6,25 +6,9 @@ describe Cloudflare::Rails do
       expect(Cloudflare::Rails::VERSION).not_to be nil
     end
 
-    describe "Railtie" do
-      let!(:rails_app) do
-        ::ActiveSupport::Dependencies.autoload_once_paths = []
-        ::ActiveSupport::Dependencies.autoload_paths = []
-        Class.new(::Rails::Application) do
-          config.active_support.deprecation = :stderr
-          config.eager_load = false
-          config.cache_store = :null_store
-          config.action_dispatch.return_only_media_type_on_content_type = false
-          config.secret_key_base = SecureRandom.hex
-          if ENV['RACK_ATTACK']
-            config.middleware.use Rack::Attack
-          end
-        end
-      end
-
-      # by default set these valid - these are the current responses from cloudflare
-      let(:ips_v4_body) do
-        <<~EOM
+    # by default set these valid - these are the current responses from cloudflare
+    let(:ips_v4_body) do
+      <<~EOM
           173.245.48.0/20
           103.21.244.0/22
           103.22.200.0/22
@@ -40,10 +24,10 @@ describe Cloudflare::Rails do
           131.0.72.0/22
           104.16.0.0/13
           104.24.0.0/14
-        EOM
-      end
-      let(:ips_v6_body) do
-        <<~EOM
+      EOM
+    end
+    let(:ips_v6_body) do
+      <<~EOM
           2400:cb00::/32
           2405:8100::/32
           2405:b500::/32
@@ -51,11 +35,54 @@ describe Cloudflare::Rails do
           2803:f800::/32
           2a06:98c0::/29
           2c0f:f248::/32
-        EOM
-      end
+      EOM
+    end
 
-      let(:ips_v4_status) { 200 }
-      let(:ips_v6_status) { 200 }
+    let(:ips_v4_status) { 200 }
+    let(:ips_v6_status) { 200 }
+    let(:base_ip) { "1.2.3.4" }
+    let(:non_cf_ip) { "8.8.4.4" }
+    let(:cf_ip) { "197.234.240.1" }
+    let(:cf_env) do
+      {
+        "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{cf_ip}",
+        'REMOTE_ADDR' => cf_ip,
+      }
+    end
+    let(:non_cf_env) do
+      {
+        "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{non_cf_ip}",
+        'REMOTE_ADDR' => non_cf_ip,
+      }
+    end
+    let(:cf_proxy_env) do
+      {
+        "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{cf_ip}, 127.0.0.1",
+        'REMOTE_ADDR' => "127.0.0.1",
+      }
+    end
+    let(:non_cf_proxy_env) do
+      {
+        "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{non_cf_ip}, 127.0.0.1",
+        'REMOTE_ADDR' => "127.0.0.1",
+      }
+    end
+
+    describe "Railtie" do
+      let!(:rails_app) do
+        ::ActiveSupport::Dependencies.autoload_once_paths = []
+        ::ActiveSupport::Dependencies.autoload_paths = []
+        Class.new(::Rails::Application) do
+          config.active_support.deprecation = :stderr
+          config.eager_load = false
+          config.cache_store = :null_store
+          config.action_dispatch.return_only_media_type_on_content_type = false
+          config.secret_key_base = SecureRandom.hex
+          if ENV['RACK_ATTACK']
+            config.middleware.use Rack::Attack
+          end
+        end
+      end
 
       before(:each) do
         if ENV['RACK_ATTACK']
@@ -76,13 +103,6 @@ describe Cloudflare::Rails do
       after(:each) do
         # clear our cache just in case (and if possible)
         Rails&.cache&.clear
-      end
-
-      if ENV['RACK_ATTACK']
-        it "monkey-patches rack-attack" do
-          rails_app.initialize!
-          expect(Rack::Attack::Request.included_modules).to include(Cloudflare::Rails::Railtie::CheckTrustedProxies)
-        end
       end
 
       it "works with valid responses" do
@@ -113,38 +133,34 @@ describe Cloudflare::Rails do
           expect(Cloudflare::Rails::Railtie::Importer.cloudflare_ips(refresh: true)).to be_blank
         end
       end
+    end
 
-      # functional tests - maybe duplicate of the remote_ip/ip tests above?
-      describe "middleware", type: :request do
-        let(:base_ip) { "1.2.3.4" }
-        let(:non_cf_ip) { "8.8.4.4" }
-        let(:cf_ip) { "197.234.240.1" }
-        let(:cf_env) do
-          {
-            "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{cf_ip}",
-            'REMOTE_ADDR' => cf_ip,
-          }
+    describe "middleware", type: :request do
+      let!(:rails_app) do
+        ::ActiveSupport::Dependencies.autoload_once_paths = []
+        ::ActiveSupport::Dependencies.autoload_paths = []
+        Class.new(::Rails::Application) do
+          config.active_support.deprecation = :stderr
+          config.eager_load = false
+          config.cache_store = :null_store
+          config.action_dispatch.return_only_media_type_on_content_type = false
+          config.secret_key_base = SecureRandom.hex
+          if ENV['RACK_ATTACK']
+            config.middleware.use Rack::Attack
+          end
         end
-        let(:non_cf_env) do
-          {
-            "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{non_cf_ip}",
-            'REMOTE_ADDR' => non_cf_ip,
-          }
-        end
-        let(:cf_proxy_env) do
-          {
-            "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{cf_ip}, 127.0.0.1",
-            'REMOTE_ADDR' => "127.0.0.1",
-          }
-        end
-        let(:non_cf_proxy_env) do
-          {
-            "HTTP_X_FORWARDED_FOR" => "#{base_ip}, #{non_cf_ip}, 127.0.0.1",
-            'REMOTE_ADDR' => "127.0.0.1",
-          }
-        end
+      end
 
-        before(:each) do
+      context 'when CLOUDFLARE_PROXY is FALSE' do
+        around :each do |example|
+          stub_request(:get, "https://www.cloudflare.com/ips-v4/").
+            to_return(status: ips_v4_status, body: ips_v4_body)
+
+          stub_request(:get, "https://www.cloudflare.com/ips-v6/").
+            to_return(status: ips_v6_status, body: ips_v6_body)
+
+          original_proxy_value = ENV.fetch('CLOUDFLARE_PROXY', nil)
+          ENV['CLOUDFLARE_PROXY'] = 'FALSE'
           class FooController < ActionController::Base
             def index
               render status: 200, json: { ip: request.ip, remote_ip: request.remote_ip }
@@ -155,41 +171,152 @@ describe Cloudflare::Rails do
           rails_app.routes.draw do
             root to: "foo#index", format: 'json'
           end
+
+          example.run
+
+          Rails&.cache&.clear
+
+          ENV['CLOUDFLARE_PROXY'] = original_proxy_value
         end
 
-        # based on code from https://github.com/rails/rails/blob/7f18ea14c893cb5c9f04d4fda9661126758332b5/railties/test/application/middleware/remote_ip_test.rb
-        def remote_ip(env = {})
-          remote_ip = nil
-          env = Rack::MockRequest.env_for("/").merge(env).merge!(
-            'action_dispatch.show_exceptions' => false,
-            'action_dispatch.key_generator' => ActiveSupport::KeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
-          )
+        # test two different ways:
+        #
+        # 1) using the ip/remote_ip methods from above
+        # 2) using a functional test with the ip/remote_ip embedded in the response
+        #    payload - this probably isn't necessary but i don't 100% understand
+        #    what the copied remote_ip code from the rails tests is actually doing.
 
-          endpoint = Proc.new do |e|
-            remote_ip = ActionDispatch::Request.new(e).remote_ip
-            [200, {}, [remote_ip]]
+        [:ip, :remote_ip].each do |m|
+          describe "request.#{m}" do
+            subject { send(m, env) }
+
+            shared_examples "it gets the correct ip address from rack" do
+              it "works" do
+                expect(subject[0]).to eq(expected_ip)
+                if ENV['RACK_ATTACK']
+                  expect(subject.dig(1, "rack.attack.throttle_data", "requests per ip", :discriminator)).to eq("197.234.240.1")
+                end
+              end
+            end
+
+            context "with a cloudflare ip" do
+              let(:env) { cf_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
+
+            context "with a non-cloudflare ip" do
+              let(:env) { non_cf_env }
+              let(:expected_ip) { non_cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
+
+            context 'with a cloudflare ip and a local proxy' do
+              let(:env) { cf_proxy_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
+
+            context 'works with a non-cloudflare ip and a local proxy' do
+              let(:env) { non_cf_proxy_env }
+              let(:expected_ip) { non_cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
+
+            context 'with an invalid ip' do
+              let(:base_ip) { "not-an-ip.test,122.175.218.25" }
+              let(:env) { cf_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rack"
+            end
           end
 
-          rails_app.middleware.build(endpoint).call(env)
-          # return our ip _and_ our env hash
-          [remote_ip, env]
+          describe "##{m}", type: :controller do
+            controller do
+              def index
+                render status: 200, json: { ip: request.ip, remote_ip: request.remote_ip }
+              end
+            end
+
+            shared_examples "it gets the correct ip address from rails" do
+              it "works" do
+                request.env.merge! env
+                get :index
+                expect(response).to have_http_status(:ok)
+                expect(JSON[response.body]["#{m}"]).to eq(expected_ip)
+              end
+            end
+
+            context "with a cloudflare ip" do
+              let(:env) { cf_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+
+            context "with a non-cloudflare ip" do
+              let(:env) { non_cf_env }
+              let(:expected_ip) { non_cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+
+            context 'with a cloudflare ip and a local proxy' do
+              let(:env) { cf_proxy_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+
+            context 'with a non-cloudflare ip and a local proxy' do
+              let(:env) { non_cf_proxy_env }
+              let(:expected_ip) { non_cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+
+            context 'with an invalid ip' do
+              let(:base_ip) { "not-an-ip.test,122.175.218.25" }
+              let(:env) { cf_env }
+              let(:expected_ip) { cf_ip }
+
+              it_behaves_like "it gets the correct ip address from rails"
+            end
+          end
         end
+      end
 
-        def ip(env = {})
-          ip = nil
-          env = Rack::MockRequest.env_for("/").merge(env).merge!(
-            'action_dispatch.show_exceptions' => false,
-            'action_dispatch.key_generator' => ActiveSupport::KeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
-          )
+      context 'when CLOUDFLARE_PROXY is TRUE' do
+        around :each do |example|
+          stub_request(:get, "https://www.cloudflare.com/ips-v4/").
+            to_return(status: ips_v4_status, body: ips_v4_body)
 
-          endpoint = Proc.new do |e|
-            ip = ActionDispatch::Request.new(e).ip
-            [200, {}, [ip]]
+          stub_request(:get, "https://www.cloudflare.com/ips-v6/").
+            to_return(status: ips_v6_status, body: ips_v6_body)
+
+          original_proxy_value = ENV.fetch('CLOUDFLARE_PROXY', nil)
+          ENV['CLOUDFLARE_PROXY'] = 'TRUE'
+          class FooController < ActionController::Base
+            def index
+              render status: 200, json: { ip: request.ip, remote_ip: request.remote_ip }
+            end
           end
 
-          rails_app.middleware.build(endpoint).call(env)
-          # return our ip _and_ our env hash
-          [ip, env]
+          rails_app.initialize!
+          rails_app.routes.draw do
+            root to: "foo#index", format: 'json'
+          end
+
+          example.run
+
+          Rails&.cache&.clear
+
+          ENV['CLOUDFLARE_PROXY'] = original_proxy_value
         end
 
         # test two different ways:
@@ -305,4 +432,39 @@ describe Cloudflare::Rails do
       end
     end
   end
+end
+
+#based on code from https://github.com/rails/rails/blob/7f18ea14c893cb5c9f04d4fda9661126758332b5/railties/test/application/middleware/remote_ip_test.rb
+def remote_ip(env = {})
+  remote_ip = nil
+  env = Rack::MockRequest.env_for("/").merge(env).merge!(
+    'action_dispatch.show_exceptions' => false,
+    'action_dispatch.key_generator' => ActiveSupport::KeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
+  )
+
+  endpoint = Proc.new do |e|
+    remote_ip = ActionDispatch::Request.new(e).remote_ip
+    [200, {}, [remote_ip]]
+  end
+
+  rails_app.middleware.build(endpoint).call(env)
+  # return our ip _and_ our env hash
+  [remote_ip, env]
+end
+
+def ip(env = {})
+  ip = nil
+  env = Rack::MockRequest.env_for("/").merge(env).merge!(
+    'action_dispatch.show_exceptions' => false,
+    'action_dispatch.key_generator' => ActiveSupport::KeyGenerator.new('b3c631c314c0bbca50c1b2843150fe33')
+  )
+
+  endpoint = Proc.new do |e|
+    ip = ActionDispatch::Request.new(e).ip
+    [200, {}, [ip]]
+  end
+
+  rails_app.middleware.build(endpoint).call(env)
+  # return our ip _and_ our env hash
+  [ip, env]
 end


### PR DESCRIPTION
We only want the behavior in this gem to kick in if we have our cloudflare proxy turned on, but don't want to have to uninstall the gem if we decide to turn it off. As such, check the env var CLOUDFLARE_PROXY upon initialization- if true, modify the app such that it excludes cloudflare ips from request.ip and request.remote_ip. If unset or not true, make no change to standard rails behavior.

Note in the specs, we test the env var being false first. This is needed because when the env var is true, we update low level rack code, the very code the spec itself is running on, which cannot easily be undone.

Because of this, specs might be flaky in a situation where the order of the tests is random, though given the specs are for a fork of a gem that I imagine we will rarely update, that won't be much of an issue. That said, any ideas for removing this flakiness would be appreciated.

Its a single commit, but the spec changes may be confusing, I'm happy to walk through.